### PR TITLE
 fix(updates/appc): spawn appc to get version

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -7,7 +7,7 @@ const dependencies = require('@seadub/danger-plugin-dependencies').default;
 async function main() {
 	await Promise.all([
 		tslint(),
-		junit({ pathToReport: './junit-report.xml' }),
+		junit({ pathToReport: './junit_report.xml' }),
 		dependencies({ type: 'npm' })
 	]);
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@seadub/danger-plugin-junit": "^0.1.1",
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^5.0.5",
-    "@types/global-modules": "^2.0.0",
     "@types/got": "^9.4.3",
     "@types/mocha": "^5.2.6",
     "@types/mock-fs": "^3.6.30",
@@ -54,7 +53,6 @@
   "dependencies": {
     "appcd-subprocess": "^1.3.0",
     "fs-extra": "^7.0.1",
-    "global-modules": "^2.0.0",
     "got": "^9.6.0",
     "libnpm": "^2.0.1",
     "semver": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "commit": "git-cz",
     "compile": "tsc -p ./",
-    "lint": "tslint -p tsconfig.json --format stylish",
+    "lint": "tslint --format stylish 'src/**/*.ts' 'tests/**/*.ts'",
     "prepack": "npm run compile",
     "release": "standard-version",
     "watch": "tsc -watch -p ./",

--- a/src/@types/appcd-subprocess/index.d.ts
+++ b/src/@types/appcd-subprocess/index.d.ts
@@ -1,26 +1,23 @@
 
-
 declare module 'appcd-subprocess' {
 	import { SpawnOptions } from 'child_process';
 
 	interface RunResponse {
-		code: number,
-		stdout: string,
-		stderr: string
+		code: number;
+		stdout: string;
+		stderr: string;
 	}
 	interface RunOptions extends SpawnOptions {
-		ignoreExitCode?: boolean
+		ignoreExitCode?: boolean;
 	}
-	function run(cmd: string, args: string[], opts: RunOptions): RunResponse;
+	function run (cmd: string, args: string[], opts: RunOptions): RunResponse;
 }
-
 
 // export const bat: string;
 
 // export const cmd: string;
 
 // export const exe: string;
-
 
 // export function spawn(params: any): any;
 

--- a/src/@types/titaniumlib/index.d.ts
+++ b/src/@types/titaniumlib/index.d.ts
@@ -1,24 +1,27 @@
 
-
 declare module 'titaniumlib' {
 	namespace sdk {
-		
-		interface InstallParams {
 
+		interface InstallParams {
+			downloadDir?: string;
+			installDir?: string;
+			keep?: boolean;
+			overwrite?: boolean;
+			uri?: string;
 		}
 
-		function getBranches(): any;
-	
-		function getBuilds(branch: string): any;
-	
-		function getInstalledSDKs(force?: boolean): any;
-	
-		function getPaths(): any;
-	
-		function getReleases(noLatest?: boolean): any;
-	
-		function install(params: any): any;
-	
-		function uninstall(nameOrPath: InstallParams): any;
+		function getBranches (): any;
+
+		function getBuilds (branch: string): any;
+
+		function getInstalledSDKs (force?: boolean): any;
+
+		function getPaths (): any;
+
+		function getReleases (noLatest?: boolean): any;
+
+		function install (params?: InstallParams): any;
+
+		function uninstall (nameOrPath: string): any;
 	}
 }

--- a/src/updates/appc/core.ts
+++ b/src/updates/appc/core.ts
@@ -10,7 +10,6 @@ import { ProductNames } from '../product-names';
 import { InstallError } from '../util';
 
 const filePath = path.join(os.homedir(), '.appcelerator', 'install', '.version');
-const RELEASE_NOTES = 'https://docs.appcelerator.com/platform/latest/?print=/guide/Appcelerator_CLI_Release_Notes';
 const LATEST_URL = 'https://registry.platform.axway.com/api/appc/latest';
 
 export async function checkForUpdate () {
@@ -24,7 +23,7 @@ export async function checkForUpdate () {
 		latestVersion,
 		action: installUpdate,
 		productName: ProductNames.AppcCore,
-		releaseNotes: RELEASE_NOTES,
+		releaseNotes: getReleaseNotes(latestVersion),
 		priority: 10,
 		hasUpdate: false
 	};
@@ -34,6 +33,7 @@ export async function checkForUpdate () {
 	}
 	return updateInfo;
 }
+
 export async function checkInstalledVersion () {
 	if (!await fs.pathExists(filePath)) {
 		return;
@@ -59,4 +59,8 @@ export async function installUpdate (version: string) {
 			stdout
 		});
 	}
+}
+
+export function getReleaseNotes (version: string) {
+	return `https://docs.appcelerator.com/platform/latest/#!/guide/Appcelerator_CLI_${version}.GA_Release_Note`;
 }

--- a/src/updates/appc/installer.ts
+++ b/src/updates/appc/installer.ts
@@ -2,11 +2,9 @@
 import { run } from 'appcd-subprocess';
 import * as libnpm from 'libnpm';
 import * as semver from 'semver';
-import { UpdateInfo, appc } from '..';
+import { UpdateInfo } from '..';
 import { ProductNames } from '../product-names';
 import * as util from '../util';
-
-const RELEASE_NOTES = 'https://docs.appcelerator.com/platform/latest/?print=/guide/Appcelerator_CLI_Release_Notes';
 
 export async function checkForUpdate () {
 	const [ currentVersion, latestVersion ] = await Promise.all([
@@ -19,7 +17,7 @@ export async function checkForUpdate () {
 		latestVersion,
 		action: installUpdate,
 		productName: ProductNames.AppcInstaller,
-		releaseNotes: RELEASE_NOTES,
+		releaseNotes: getReleaseNotes(),
 		priority: 10,
 		hasUpdate: false
 	};
@@ -75,4 +73,9 @@ export async function installUpdate (version: string) {
 		}
 		throw new util.InstallError('Failed to install package', metadata);
 	}
+}
+
+export function getReleaseNotes () {
+	// There are no public release notes for appc-install, so just point to the latest CLI release notes
+	return `https://docs.appcelerator.com/platform/latest/#!/guide/Appcelerator_CLI_Release_Notes`;
 }

--- a/src/updates/titanium/sdk.ts
+++ b/src/updates/titanium/sdk.ts
@@ -4,8 +4,6 @@ import { UpdateInfo } from '..';
 import { ProductNames } from '../product-names';
 import * as util from '../util';
 
-const RELEASE_NOTES = 'https://docs.appcelerator.com/platform/latest/?print=/guide/Titanium_SDK_Release_Notes';
-
 export async function checkForUpdate () {
 	const [ currentVersion, latestVersion ] = await Promise.all([
 		checkInstalledVersion(),
@@ -17,7 +15,7 @@ export async function checkForUpdate () {
 		latestVersion: latestVersion.name,
 		action: installUpdate,
 		productName: ProductNames.TitaniumSDK,
-		releaseNotes: RELEASE_NOTES,
+		releaseNotes: getReleaseNotes(latestVersion.name),
 		priority: 100,
 		hasUpdate: false
 	};
@@ -63,4 +61,8 @@ export async function installUpdate (version: string) {
 		throw new util.InstallError('Failed to install package', error);
 	}
 
+}
+
+export function getReleaseNotes(version: string) {
+	return `https://docs.appcelerator.com/platform/latest/#!/guide/Titanium_SDK_${version}_Release_Note`;
 }

--- a/src/updates/titanium/sdk.ts
+++ b/src/updates/titanium/sdk.ts
@@ -63,6 +63,6 @@ export async function installUpdate (version: string) {
 
 }
 
-export function getReleaseNotes(version: string) {
+export function getReleaseNotes (version: string) {
 	return `https://docs.appcelerator.com/platform/latest/#!/guide/Titanium_SDK_${version}_Release_Note`;
 }

--- a/src/updates/util.ts
+++ b/src/updates/util.ts
@@ -1,6 +1,3 @@
-import globalNpmPath from 'global-modules';
-import * as path from 'path';
-
 export class InstallError extends Error {
 	public code: string;
 	public metadata: object;
@@ -14,8 +11,4 @@ export class InstallError extends Error {
 		this.code = 'EINSTALLFAILED';
 		this.metadata = metadata || {};
 	}
-}
-
-export function getNpmPackagePath (packageName: string) {
-	return path.join(globalNpmPath, packageName, 'package.json');
 }

--- a/tests/fixtures/network/network-mocks.ts
+++ b/tests/fixtures/network/network-mocks.ts
@@ -1,31 +1,31 @@
 import nock from 'nock';
 import * as path from 'path';
 
-export function mockAppcCoreRequest(version: string) {
+export function mockAppcCoreRequest (version: string) {
 	nock('https://registry.platform.axway.com')
 		.get('/api/appc/latest')
-		.reply(200,{
-			"key": "result",
-			"request-id": "6c4fb0e4-a84c-4e46-8d21-c4dee184a84d",
-			"result": [
+		.reply(200, {
+			'key': 'result',
+			'request-id': '6c4fb0e4-a84c-4e46-8d21-c4dee184a84d',
+			'result': [
 				{
-					"id": "55d62d2a6c03980c1d58fc47",
-					"name": "appc-cli/appcelerator",
-					"version": version
+					id: '55d62d2a6c03980c1d58fc47',
+					name: 'appc-cli/appcelerator',
+					version
 				}
 			],
-			"success": true
+			'success': true
 		});
 }
 
-export function mockSDKRequest(file: string) {
+export function mockSDKRequest (file: string) {
 	nock('https://s3-us-west-2.amazonaws.com')
 		.get('/appc-mobilesdk-server/releases.json')
 		.replyWithFile(200, path.join(__dirname, file));
 
 }
 
-export function mockNpmRequest() {
+export function mockNpmRequest () {
 	nock('https://registry.npmjs.org')
 		.get('/appcelerator')
 		.replyWithFile(200, path.join(__dirname, 'npm-response.json'));

--- a/tests/updates-test.ts
+++ b/tests/updates-test.ts
@@ -37,66 +37,66 @@ describe('updates', () => {
 	});
 
 	describe('titanium.sdk', () => {
-		it('checkForUpdate with installed SDKS', async function () {
+		it('checkForUpdate with installed SDKS', async () => {
 			const sdkStub = sandbox.stub(titaniumlib.sdk, 'getInstalledSDKs');
 
 			sdkStub.returns([
 				{
-					"name": "7.0.2.GA",
-					"manifest": {
-						"name": "7.0.2.v20180209105903",
-						"version": "7.0.2",
-						"moduleAPIVersion": {
-							"iphone": "2",
-							"android": "4",
-							"windows": "4"
+					name: '7.0.2.GA',
+					manifest: {
+						name: '7.0.2.v20180209105903',
+						version: '7.0.2',
+						moduleAPIVersion: {
+							iphone: '2',
+							android: '4',
+							windows: '4'
 						},
-						"timestamp": "2/9/2018 19:05",
-						"githash": "5ef0c56",
-						"platforms": [
-							"iphone",
-							"android"
+						timestamp: '2/9/2018 19:05',
+						githash: '5ef0c56',
+						platforms: [
+							'iphone',
+							'android'
 						]
 					},
-					"path": "/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/7.0.2.GA"
+					path: '/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/7.0.2.GA'
 				},
 				{
-					"name": "7.5.0.GA",
-					"manifest": {
-						"name": "7.5.0.v20181115134726",
-						"version": "7.5.0",
-						"moduleAPIVersion": {
-							"iphone": "2",
-							"android": "4",
-							"windows": "6"
+					name: '7.5.0.GA',
+					manifest: {
+						name: '7.5.0.v20181115134726',
+						version: '7.5.0',
+						moduleAPIVersion: {
+							iphone: '2',
+							android: '4',
+							windows: '6'
 						},
-						"timestamp": "11/15/2018 21:52",
-						"githash": "2e5a7423d0",
-						"platforms": [
-							"iphone",
-							"android"
+						timestamp: '11/15/2018 21:52',
+						githash: '2e5a7423d0',
+						platforms: [
+							'iphone',
+							'android'
 						]
 					},
-					"path": "/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/7.5.0.GA"
+					path: '/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/7.5.0.GA'
 				},
 				{
-					"name": "8.1.0.v20190416065710",
-					"manifest": {
-						"name": "8.1.0.v20190416065710",
-						"version": "8.1.0",
-						"moduleAPIVersion": {
-							"iphone": "2",
-							"android": "4",
-							"windows": "7"
+					name: '8.1.0.v20190416065710',
+					manifest: {
+						name: '8.1.0.v20190416065710',
+						version: '8.1.0',
+						moduleAPIVersion: {
+							iphone: '2',
+							android: '4',
+							windows: '7'
 						},
-						"timestamp": "4/16/2019 14:03",
-						"githash": "37f6d88",
-						"platforms": [
-							"iphone",
-							"android"
+						timestamp: '4/16/2019 14:03',
+						githash: '37f6d88',
+						platforms: [
+							'iphone',
+							'android'
 						]
 					},
-					"path": "/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/8.1.0.v20190416065710"
+					path: '/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/8.1.0.v20190416065710'
 				}
 			]);
 
@@ -109,7 +109,7 @@ describe('updates', () => {
 			expect(update.hasUpdate).to.equal(true);
 		});
 
-		it('checkForUpdate with no installed SDKS', async function () {
+		it('checkForUpdate with no installed SDKS', async () => {
 			const sdkStub = sandbox.stub(titaniumlib.sdk, 'getInstalledSDKs');
 
 			sdkStub.returns([]);
@@ -123,46 +123,46 @@ describe('updates', () => {
 			expect(update.hasUpdate).to.equal(true);
 		});
 
-		it('checkForUpdate with latest installed', async function () {
+		it('checkForUpdate with latest installed', async () => {
 			const sdkStub = sandbox.stub(titaniumlib.sdk, 'getInstalledSDKs');
 
 			sdkStub.returns([
 				{
-					"name": "8.0.0.GA",
-					"manifest": {
-						"name": "8.0.0.v20190314105657",
-						"version": "8.0.0",
-						"moduleAPIVersion": {
-							"iphone": "2",
-							"android": "4",
-							"windows": "7"
+					name: '8.0.0.GA',
+					manifest: {
+						name: '8.0.0.v20190314105657',
+						version: '8.0.0',
+						moduleAPIVersion: {
+							iphone: '2',
+							android: '4',
+							windows: '7'
 						},
-						"githash": "3726240fa2",
-						"platforms": [
-							"iphone",
-							"android"
+						githash: '3726240fa2',
+						platforms: [
+							'iphone',
+							'android'
 						]
 					},
-					"path": "/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/8.0.0.GA"
+					path: '/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/8.0.0.GA'
 				},
 				{
-					"name": "8.1.0.v20190416065710",
-					"manifest": {
-						"name": "8.1.0.v20190416065710",
-						"version": "8.1.0",
-						"moduleAPIVersion": {
-							"iphone": "2",
-							"android": "4",
-							"windows": "7"
+					name: '8.1.0.v20190416065710',
+					manifest: {
+						name: '8.1.0.v20190416065710',
+						version: '8.1.0',
+						moduleAPIVersion: {
+							iphone: '2',
+							android: '4',
+							windows: '7'
 						},
-						"timestamp": "4/16/2019 14:03",
-						"githash": "37f6d88",
-						"platforms": [
-							"iphone",
-							"android"
+						timestamp: '4/16/2019 14:03',
+						githash: '37f6d88',
+						platforms: [
+							'iphone',
+							'android'
 						]
 					},
-					"path": "/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/8.1.0.v20190416065710"
+					path: '/Users/eharris/Library/Application Support/Titanium/mobilesdk/osx/8.1.0.v20190416065710'
 				}
 			]);
 
@@ -244,7 +244,7 @@ describe('updates', () => {
 			mockNpmRequest();
 			const appcChild = createChildMock();
 			const npmChild = createChildMock();
-			
+
 			const stub = sandbox.stub(child_process, 'spawn');
 
 			stub
@@ -292,7 +292,7 @@ describe('updates', () => {
 	});
 
 	describe('appc.core', () => {
-		it('checkForUpdate with install', async function () {
+		it('checkForUpdate with install', async () => {
 			mockFS({
 				[filePath]: '4.2.0'
 			});
@@ -304,7 +304,7 @@ describe('updates', () => {
 			expect(update.hasUpdate).to.equal(true);
 		});
 
-		it('checkForUpdate with no install', async function () {
+		it('checkForUpdate with no install', async () => {
 			mockFS({});
 			mockAppcCoreRequest('6.6.6');
 			const update = await appc.core.checkForUpdate();
@@ -314,7 +314,7 @@ describe('updates', () => {
 			expect(update.hasUpdate).to.equal(true);
 		});
 
-		it('checkForUpdate with latest installed', async function () {
+		it('checkForUpdate with latest installed', async () => {
 			mockFS({
 				[filePath]: '6.6.6'
 			});

--- a/tslint.json
+++ b/tslint.json
@@ -30,10 +30,5 @@
             "allow-pascal-case",
             "allow-leading-underscore"
         ]
-    },
-    "linterOptions": {
-        "exclude": [
-            "scripts/*.js"
-        ]
     }
 }


### PR DESCRIPTION
Due to global-modules using process.execPath as a last resort to resolve the global node_modules directory when running under Electron the directory returned is invalid. Spawning appc, while more costly, guarantees us to be given the right version