### PR TITLE
fix(updates/core): correct core check to improve usage when using dev env setup

### DIFF
--- a/src/updates/appc/core.ts
+++ b/src/updates/appc/core.ts
@@ -9,7 +9,8 @@ import { UpdateInfo } from '..';
 import { ProductNames } from '../product-names';
 import { InstallError } from '../util';
 
-const filePath = path.join(os.homedir(), '.appcelerator', 'install', '.version');
+const appcHomeDir = path.join(os.homedir(), '.appcelerator');
+const versionFilePath = path.join(appcHomeDir, 'install', '.version');
 const LATEST_URL = 'https://registry.platform.axway.com/api/appc/latest';
 
 export async function checkForUpdate () {
@@ -35,10 +36,12 @@ export async function checkForUpdate () {
 }
 
 export async function checkInstalledVersion () {
-	if (!await fs.pathExists(filePath)) {
+	if (!await fs.pathExists(versionFilePath)) {
 		return;
 	}
-	const version = await fs.readFile(filePath, 'utf8');
+	const cliVersion = await fs.readFile(versionFilePath, 'utf8');
+	const packageJson = path.join(appcHomeDir, 'install', cliVersion, 'packages', 'package.json');
+	const { version } = await fs.readJSON(packageJson);
 	return version;
 }
 

--- a/tests/environment-test.ts
+++ b/tests/environment-test.ts
@@ -11,9 +11,9 @@ import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import stream from 'stream';
-import { mockAppcCoreRequest, mockNpmRequest } from './fixtures/network/network-mocks';
 
-const filePath = path.join(os.homedir(), '.appcelerator', 'install', '.version');
+const appcHomeDir = path.join(os.homedir(), '.appcelerator');
+const versionFilePath = path.join(appcHomeDir, 'install', '.version');
 let sandbox: sinon.SinonSandbox;
 
 function createChildMock () {
@@ -81,8 +81,10 @@ describe('environment', () => {
 				}
 			]);
 
+			const packageJson = path.join(appcHomeDir, 'install', '4.2.0', 'packages', 'package.json');
 			mockFS({
-				[filePath]: '4.2.0'
+				[versionFilePath]: '4.2.0',
+				[packageJson]: '{ "version": "4.2.0" }'
 			});
 
 			const appcChild = createChildMock();
@@ -108,8 +110,10 @@ describe('environment', () => {
 
 			sdkStub.returns([]);
 
+			const packageJson = path.join(appcHomeDir, 'install', '4.2.0', 'packages', 'package.json');
 			mockFS({
-				[filePath]: '4.2.0'
+				[versionFilePath]: '4.2.0',
+				[packageJson]: '{ "version": "4.2.0" }'
 			});
 
 			const appcChild = createChildMock();
@@ -175,8 +179,10 @@ describe('environment', () => {
 				}
 			]);
 
+			const packageJson = path.join(appcHomeDir, 'install', '4.2.0', 'packages', 'package.json');
 			mockFS({
-				[filePath]: '4.2.0'
+				[versionFilePath]: '4.2.0',
+				[packageJson]: '{ "version": "4.2.0" }'
 			});
 
 			const appcChild = createChildMock();


### PR DESCRIPTION
As our dev environment usually involves the folder directory and the version in package.json differing the existing check was techinically wrong, this corrects it to use the package.json to make it more correct