### PR TITLE
fix(update): make nodejs supported versions optional

### DIFF
--- a/src/updates/index.ts
+++ b/src/updates/index.ts
@@ -14,7 +14,7 @@ interface UpdateInfo {
 }
 
 export interface SupportedVersions {
-	nodeJS: string;
+	nodeJS?: string;
 }
 
 async function checkAllUpdates(supportedVersions?: SupportedVersions): Promise<UpdateInfo[]> {


### PR DESCRIPTION
Missed making this optional and ended up throwing a lint warning in vscode