### PR TITLE
fix(updates): set NODE_ENV environment variable so that npm does not filter

### DIFF
--- a/src/updates/util.ts
+++ b/src/updates/util.ts
@@ -33,7 +33,8 @@ export class InstallError extends Error {
  */
 export async function checkInstalledNpmPackageVersion (name: string): Promise<string|undefined> {
 	try {
-		const { stdout } = await exec('npm', [ 'ls', `${name}`, '--json', '--depth', '0', '--global' ], { shell: true });
+		// We have to force NODE_ENV to undefined as atom has it always set to production which breaks npm ls
+		const { stdout } = await exec('npm', [ 'ls', `${name}`, '--json', '--depth', '0', '--global' ], { shell: true, env: { ...process.env, NODE_ENV: undefined }  });
 		const { dependencies } = JSON.parse(stdout);
 		return dependencies[name]?.version;
 	} catch (error) {


### PR DESCRIPTION
When running npm ls, if npm detects a NODE_ENV environment variable it will filter dependent on
that, atom will set this to production which means that npm ls will not return the global packages,
so explicitly set it to undefined so we can correctly get those packages.

Maybe I'll remember this next time